### PR TITLE
Various minor improvements to the build workflows

### DIFF
--- a/.github/workflows/dynalite.yml
+++ b/.github/workflows/dynalite.yml
@@ -46,6 +46,12 @@ jobs:
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_TOKEN }}
 
+      - name: Test build
+        if: github.ref != 'refs/heads/main'
+        uses: docker/build-push-action@v3.2.0
+        with:
+          context: dynalite/
+
       - name: Build and push
         if: github.ref == 'refs/heads/main'
         uses: docker/build-push-action@v3.2.0

--- a/.github/workflows/dynalite.yml
+++ b/.github/workflows/dynalite.yml
@@ -9,6 +9,10 @@ on:
       - .github/workflows/dynalite.yml
       - dynalite/**
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   dynalite:
     runs-on: ubuntu-22.04

--- a/.github/workflows/dynalite.yml
+++ b/.github/workflows/dynalite.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   dynalite:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/dynalite.yml
+++ b/.github/workflows/dynalite.yml
@@ -3,8 +3,6 @@ name: dynalite
 
 on:
   push:
-    branches:
-      - main
     paths:
       - .github/workflows/dynalite.yml
       - dynalite/**

--- a/.github/workflows/dynalite.yml
+++ b/.github/workflows/dynalite.yml
@@ -43,6 +43,7 @@ jobs:
           password: ${{ secrets.QUAY_TOKEN }}
 
       - name: Build and push
+        if: github.ref == 'refs/heads/main'
         uses: docker/build-push-action@v3.2.0
         with:
           context: dynalite/

--- a/.github/workflows/dynalite.yml
+++ b/.github/workflows/dynalite.yml
@@ -2,7 +2,13 @@
 name: dynalite
 
 on:
+  pull_request:
+    paths:
+      - .github/workflows/dynalite.yml
+      - dynalite/**
   push:
+    branches:
+      - main
     paths:
       - .github/workflows/dynalite.yml
       - dynalite/**

--- a/.github/workflows/fpm.yml
+++ b/.github/workflows/fpm.yml
@@ -46,6 +46,13 @@ jobs:
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_TOKEN }}
 
+      - name: Test build fpm:latest
+        if: github.ref != 'refs/heads/main'
+        uses: docker/build-push-action@v3.2.0
+        with:
+          context: fpm/
+          target: with-entrypoint
+
       - name: Build and push fpm:latest
         if: github.ref == 'refs/heads/main'
         uses: docker/build-push-action@v3.2.0
@@ -61,6 +68,13 @@ jobs:
             linux/arm64
           push: true
           cache-to: type=local,mode=max,dest=/tmp/.buildx-cache
+
+      - name: Test build fpm:latest
+        if: github.ref != 'refs/heads/main'
+        uses: docker/build-push-action@v3.2.0
+        with:
+          context: fpm/
+          target: no-entrypoint
 
       - name: Build and push fpm:no-entrypoint
         if: github.ref == 'refs/heads/main'

--- a/.github/workflows/fpm.yml
+++ b/.github/workflows/fpm.yml
@@ -9,6 +9,10 @@ on:
       - .github/workflows/fpm.yml
       - fpm/**
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   fpm:
     runs-on: ubuntu-22.04

--- a/.github/workflows/fpm.yml
+++ b/.github/workflows/fpm.yml
@@ -2,7 +2,13 @@
 name: fpm
 
 on:
+  pull_request:
+    paths:
+      - .github/workflows/fpm.yml
+      - fpm/**
   push:
+    branches:
+      - main
     paths:
       - .github/workflows/fpm.yml
       - fpm/**

--- a/.github/workflows/fpm.yml
+++ b/.github/workflows/fpm.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   fpm:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/fpm.yml
+++ b/.github/workflows/fpm.yml
@@ -43,6 +43,7 @@ jobs:
           password: ${{ secrets.QUAY_TOKEN }}
 
       - name: Build and push fpm:latest
+        if: github.ref == 'refs/heads/main'
         uses: docker/build-push-action@v3.2.0
         with:
           context: fpm/
@@ -58,6 +59,7 @@ jobs:
           cache-to: type=local,mode=max,dest=/tmp/.buildx-cache
 
       - name: Build and push fpm:no-entrypoint
+        if: github.ref == 'refs/heads/main'
         uses: docker/build-push-action@v3.2.0
         with:
           context: fpm/

--- a/.github/workflows/fpm.yml
+++ b/.github/workflows/fpm.yml
@@ -3,8 +3,6 @@ name: fpm
 
 on:
   push:
-    branches:
-      - main
     paths:
       - .github/workflows/fpm.yml
       - fpm/**

--- a/.github/workflows/http-echo-test.yml
+++ b/.github/workflows/http-echo-test.yml
@@ -43,6 +43,7 @@ jobs:
           password: ${{ secrets.QUAY_TOKEN }}
 
       - name: Build and push
+        if: github.ref == 'refs/heads/main'
         uses: docker/build-push-action@v3.2.0
         with:
           context: http-echo-test/

--- a/.github/workflows/http-echo-test.yml
+++ b/.github/workflows/http-echo-test.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   http-echo-test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/http-echo-test.yml
+++ b/.github/workflows/http-echo-test.yml
@@ -9,6 +9,10 @@ on:
       - .github/workflows/http-echo-test.yml
       - http-echo-test/**
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   http-echo-test:
     runs-on: ubuntu-22.04

--- a/.github/workflows/http-echo-test.yml
+++ b/.github/workflows/http-echo-test.yml
@@ -3,8 +3,6 @@ name: http-echo-test
 
 on:
   push:
-    branches:
-      - main
     paths:
       - .github/workflows/http-echo-test.yml
       - http-echo-test/**

--- a/.github/workflows/http-echo-test.yml
+++ b/.github/workflows/http-echo-test.yml
@@ -2,7 +2,13 @@
 name: http-echo-test
 
 on:
+  pull_request:
+    paths:
+      - .github/workflows/http-echo-test.yml
+      - http-echo-test/**
   push:
+    branches:
+      - main
     paths:
       - .github/workflows/http-echo-test.yml
       - http-echo-test/**

--- a/.github/workflows/http-echo-test.yml
+++ b/.github/workflows/http-echo-test.yml
@@ -46,6 +46,12 @@ jobs:
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_TOKEN }}
 
+      - name: Test build
+        if: github.ref != 'refs/heads/main'
+        uses: docker/build-push-action@v3.2.0
+        with:
+          context: http-echo-test/
+
       - name: Build and push
         if: github.ref == 'refs/heads/main'
         uses: docker/build-push-action@v3.2.0

--- a/.github/workflows/kinesalite.yml
+++ b/.github/workflows/kinesalite.yml
@@ -46,6 +46,12 @@ jobs:
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_TOKEN }}
 
+      - name: Test build
+        if: github.ref != 'refs/heads/main'
+        uses: docker/build-push-action@v3.2.0
+        with:
+          context: kinesalite/
+
       - name: Build and push
         if: github.ref == 'refs/heads/main'
         uses: docker/build-push-action@v3.2.0

--- a/.github/workflows/kinesalite.yml
+++ b/.github/workflows/kinesalite.yml
@@ -2,7 +2,13 @@
 name: kinesalite
 
 on:
+  pull_request:
+    paths:
+      - .github/workflows/kinesalite.yml
+      - kinesalite/**
   push:
+    branches:
+      - main
     paths:
       - .github/workflows/kinesalite.yml
       - kinesalite/**

--- a/.github/workflows/kinesalite.yml
+++ b/.github/workflows/kinesalite.yml
@@ -9,6 +9,10 @@ on:
       - .github/workflows/kinesalite.yml
       - kinesalite/**
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   kinesalite:
     runs-on: ubuntu-22.04

--- a/.github/workflows/kinesalite.yml
+++ b/.github/workflows/kinesalite.yml
@@ -3,8 +3,6 @@ name: kinesalite
 
 on:
   push:
-    branches:
-      - main
     paths:
       - .github/workflows/kinesalite.yml
       - kinesalite/**

--- a/.github/workflows/kinesalite.yml
+++ b/.github/workflows/kinesalite.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   kinesalite:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/kinesalite.yml
+++ b/.github/workflows/kinesalite.yml
@@ -43,6 +43,7 @@ jobs:
           password: ${{ secrets.QUAY_TOKEN }}
 
       - name: Build and push
+        if: github.ref == 'refs/heads/main'
         uses: docker/build-push-action@v3.2.0
         with:
           context: kinesalite/

--- a/.github/workflows/uwsgi-werkzeug-echo.yml
+++ b/.github/workflows/uwsgi-werkzeug-echo.yml
@@ -43,6 +43,7 @@ jobs:
           password: ${{ secrets.QUAY_TOKEN }}
 
       - name: Build and push
+        if: github.ref == 'refs/heads/main'
         uses: docker/build-push-action@v3.2.0
         with:
           context: uwsgi-werkzeug-echo/

--- a/.github/workflows/uwsgi-werkzeug-echo.yml
+++ b/.github/workflows/uwsgi-werkzeug-echo.yml
@@ -46,6 +46,12 @@ jobs:
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_TOKEN }}
 
+      - name: Test build
+        if: github.ref != 'refs/heads/main'
+        uses: docker/build-push-action@v3.2.0
+        with:
+          context: uwsgi-werkzeug-echo/
+
       - name: Build and push
         if: github.ref == 'refs/heads/main'
         uses: docker/build-push-action@v3.2.0

--- a/.github/workflows/uwsgi-werkzeug-echo.yml
+++ b/.github/workflows/uwsgi-werkzeug-echo.yml
@@ -2,7 +2,13 @@
 name: uwsgi-werkzeug-echo
 
 on:
+  pull_request:
+    paths:
+      - .github/workflows/uwsgi-werkzeug-echo.yml
+      - uwsgi-werkzeug-echo/**
   push:
+    branches:
+      - main
     paths:
       - .github/workflows/uwsgi-werkzeug-echo.yml
       - uwsgi-werkzeug-echo/**

--- a/.github/workflows/uwsgi-werkzeug-echo.yml
+++ b/.github/workflows/uwsgi-werkzeug-echo.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   uwsgi-werkzeug-echo:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/uwsgi-werkzeug-echo.yml
+++ b/.github/workflows/uwsgi-werkzeug-echo.yml
@@ -3,8 +3,6 @@ name: uwsgi-werkzeug-echo
 
 on:
   push:
-    branches:
-      - main
     paths:
       - .github/workflows/uwsgi-werkzeug-echo.yml
       - uwsgi-werkzeug-echo/**

--- a/.github/workflows/uwsgi-werkzeug-echo.yml
+++ b/.github/workflows/uwsgi-werkzeug-echo.yml
@@ -9,6 +9,10 @@ on:
       - .github/workflows/uwsgi-werkzeug-echo.yml
       - uwsgi-werkzeug-echo/**
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   uwsgi-werkzeug-echo:
     runs-on: ubuntu-22.04

--- a/fpm/Dockerfile
+++ b/fpm/Dockerfile
@@ -47,7 +47,8 @@ RUN gem install fpm --version=1.14.2 && \
 RUN mkdir /tmp/tests && \
     pushd /tmp/tests && \
     echo 'This is a test' > package-data && \
-
+    #
+    # Dir to * tests
     # dir -> dir
     fpm --input-type=dir --output-type=dir --name=test package-data && \
     # dir -> deb
@@ -70,7 +71,8 @@ RUN mkdir /tmp/tests && \
     fpm --input-type=dir --output-type=sh --name=test package-data && \
     # dir -> zip
     fpm --input-type=dir --output-type=zip --name=test package-data && \
-
+    #
+    # * to dir tests
     # gem -> dir
     fpm --input-type=gem --output-type=dir test && \
     # deb -> dir
@@ -99,7 +101,8 @@ RUN mkdir /tmp/tests && \
     fpm --input-type=virtualenv --output-type=dir cowsay && \
     # zip -> dir
     fpm --input-type=zip --output-type=dir --package=zip test.zip && \
-
+    #
+    # Cleanup
     popd && \
     rm -r /tmp/tests
 


### PR DESCRIPTION
- Use Ubuntu 22.04 runners
- Request the necessary permissions for pushing images to GHCR in workflows (necessary for builds triggered by Dependabot)
- Only attempt to push Docker images when changes are merged into main
- Add a test build of Docker images on PRs
- Remove warnings when building fpm image about empty continuation lines