### PR TITLE
Upgrade Dynalite to version 3.2.2

### DIFF
--- a/dynalite/Dockerfile
+++ b/dynalite/Dockerfile
@@ -8,7 +8,7 @@ RUN apk add --no-cache tini \
         g++ \
         make \
         python \
-    && su node -c "npm install --global dynalite@3.2.1" \
+    && su node -c "npm install --global dynalite@3.2.2" \
     && su node -c "npm cache clean --force" \
     && apk del .install-deps \
     && mkdir /var/lib/dynalite \

--- a/dynalite/Dockerfile
+++ b/dynalite/Dockerfile
@@ -4,18 +4,15 @@ ENV NPM_CONFIG_PREFIX=/home/node/.npm-global \
     PATH=$PATH:/home/node/.npm-global/bin
 
 RUN apk add --no-cache tini \
-    && apk add --no-cache --virtual .install-deps \
-        g++ \
-        make \
-        python \
     && su node -c "npm install --global dynalite@3.2.2" \
     && su node -c "npm cache clean --force" \
-    && apk del .install-deps \
     && mkdir /var/lib/dynalite \
     && chown node:node /var/lib/dynalite
 
 USER node
 EXPOSE 4567
 VOLUME /var/lib/dynalite
+
+RUN dynalite --help
 
 ENTRYPOINT ["/sbin/tini", "--", "dynalite", "--path=/var/lib/dynalite"]

--- a/dynalite/Dockerfile
+++ b/dynalite/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10-alpine
+FROM node:18-alpine
 
 ENV NPM_CONFIG_PREFIX=/home/node/.npm-global \
     PATH=$PATH:/home/node/.npm-global/bin


### PR DESCRIPTION
The release came out almost a year ago, but I wasn't alerted because the maintainer didn't make a release on GitHub for it.

This also upgrades Node.js to the latest LTS release and tidies up the Docker image slightly.