### PR TITLE
Add GCC as a dependency for the FPM Docker image

### DIFF
--- a/fpm/Dockerfile
+++ b/fpm/Dockerfile
@@ -11,6 +11,7 @@ RUN <<EOF
         cpio \
         cpp \
         curl \
+        gcc \
         libarchive-tools \
         make \
         php-pear \


### PR DESCRIPTION
FPM depends on rexml which in turn has started to depend on strscan, which is a native extension and thus requires a compiler.